### PR TITLE
Update csv2libsvm.py

### DIFF
--- a/csv2libsvm.py
+++ b/csv2libsvm.py
@@ -41,8 +41,8 @@ try:
 except IndexError:
 	skip_headers = 0
 
-i = open( input_file, 'rb' )
-o = open( output_file, 'wb' )
+i = open( input_file, 'r' )
+o = open( output_file, 'w' )
 
 reader = csv.reader( i )
 


### PR DESCRIPTION
_csv.Error: iterator should return strings, not bytes error was coming in python 3 since the file was opened in binary mode.
Hence removing the binary mode.